### PR TITLE
suppress annoying errors

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -176,7 +176,7 @@ bench_simple_signal()
   const uint64_t end_counter = TestCounter::get();
   assert (end_counter - start_counter == i);
   printf ("OK\n  Benchmark: Simple::Signal: %fns per emission (size=%u): ", size_t (benchdone - benchstart) * 1.0 / size_t (i),
-          sizeof (sig_increment));
+          (unsigned int) sizeof (sig_increment));
 }
 
 static void


### PR DESCRIPTION
As suggested within the file `test.cpp`, one should use the following line to compile it:

```
g++ -Wall -O2 -std=gnu++11 -pthread test.cpp && ./a.out
```

Anyway, on some systems it results in the following annoying error:

> test.cpp: In function ‘void bench_simple_signal()’:
> test.cpp:179:33: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘long unsigned int’ [-Wformat=]

An explicit cast will suppress that warning.
