### PR TITLE
-fsanitize indicates minor memory leak with size()

### DIFF
--- a/SimpleSignal.h
+++ b/SimpleSignal.h
@@ -198,6 +198,7 @@ public:
         old->decref();
       }
     while (link != callback_ring_);
+    link->decref();
     return size;
   }
 };

--- a/test.cpp
+++ b/test.cpp
@@ -1,6 +1,7 @@
 #include "SimpleSignal.h"
 
 // g++ -Wall -O2 -std=gnu++11 -pthread test.cpp && ./a.out
+// append -fsanitize=address for memory debugging
 
 #include <string>
 #include <stdarg.h>

--- a/test.cpp
+++ b/test.cpp
@@ -114,6 +114,7 @@ class TestCollectorVector {
     sig_vector.connect(handler777);
     std::vector<int> results = sig_vector.emit();
     const std::vector<int> reference = { 777, 42, 1, 42, 777, };
+    assert(5 == sig_vector.size());
     assert (results == reference);
   }
 };


### PR DESCRIPTION
compile with -fsanitize=address to note small leak when using size(); fixed by adding a decref() call at the end of the while loop when calculating size

