### PR TITLE
replaced the linked ring with reference count with simple std::list and std::shared_ptr

### DIFF
--- a/SimpleSignal.h
+++ b/SimpleSignal.h
@@ -1,11 +1,12 @@
 // CC0 Public Domain: http://creativecommons.org/publicdomain/zero/1.0/
 #pragma once
 
-#include <unistd.h>
-#include <assert.h>
-#include <stdint.h>
+// #include <unistd.h>
+// #include <stdint.h>
 #include <functional>
+#include <list>
 #include <vector>
+#include <algorithm>
 
 namespace Simple {
 
@@ -68,138 +69,66 @@ protected:
   using CbFunction = std::function<R (Args...)>;
   using Result = typename CbFunction::result_type;
   using CollectorResult = typename Collector::CollectorResult;
+
 private:
-  /// SignalLink implements a doubly-linked ring with ref-counted nodes containing the signal handlers.
-  struct SignalLink {
-    SignalLink *next, *prev;
-    CbFunction  function;
-    int         ref_count;
-    explicit    SignalLink (const CbFunction &cbf) : next (nullptr), prev (nullptr), function (cbf), ref_count (1) {}
-    /*dtor*/   ~SignalLink ()           { assert (ref_count == 0); }
-    void        incref     ()           { ref_count += 1; assert (ref_count > 0); }
-    void        decref     ()           { ref_count -= 1; if (!ref_count) delete this; else assert (ref_count > 0); }
-    void
-    unlink ()
-    {
-      function = nullptr;
-      if (next)
-        next->prev = prev;
-      if (prev)
-        prev->next = next;
-      decref();
-      // leave intact ->next, ->prev for stale iterators
-    }
-    size_t
-    add_before (const CbFunction &cb)
-    {
-      SignalLink *link = new SignalLink (cb);
-      link->prev = prev; // link to last
-      link->next = this;
-      prev->next = link; // link from last
-      prev = link;
-      static_assert (sizeof (link) == sizeof (size_t), "sizeof size_t");
-      return size_t (link);
-    }
-    bool
-    remove_sibling (size_t id)
-    {
-      for (SignalLink *link = this->next ? this->next : this; link != this; link = link->next)
-        if (id == size_t (link))
-          {
-            link->unlink();     // deactivate and unlink sibling
-            return true;
-          }
-      return false;
-    }
-  };
-  SignalLink   *callback_ring_; // linked ring of callback nodes
   /*copy-ctor*/ ProtoSignal (const ProtoSignal&) = delete;
   ProtoSignal&  operator=   (const ProtoSignal&) = delete;
-  void
-  ensure_ring ()
+
+  using CallbackSlot = std::shared_ptr<CbFunction>;
+  using CallbackList = std::list<CallbackSlot>;
+  CallbackList callback_list_;
+
+  size_t add_cb(const CbFunction& cb)
   {
-    if (!callback_ring_)
-      {
-        callback_ring_ = new SignalLink (CbFunction()); // ref_count = 1
-        callback_ring_->incref(); // ref_count = 2, head of ring, can be deactivated but not removed
-        callback_ring_->next = callback_ring_; // ring head initialization
-        callback_ring_->prev = callback_ring_; // ring tail initialization
-      }
+    callback_list_.emplace_back(std::make_shared<CbFunction>(cb));
+    return size_t (callback_list_.back().get());
   }
+
+  bool remove_cb(size_t id)
+  {
+    auto it =std::remove_if(begin(callback_list_), end(callback_list_),
+                            [id](const CallbackSlot& slot) { return size_t(slot.get()) == id; });
+    bool const removed = it != end(callback_list_);
+    callback_list_.erase(it, end(callback_list_));
+    return removed;
+  }
+
 public:
   /// ProtoSignal constructor, connects default callback if non-nullptr.
-  ProtoSignal (const CbFunction &method) :
-    callback_ring_ (nullptr)
+  ProtoSignal (const CbFunction &method)
   {
-    if (method != nullptr)
-      {
-        ensure_ring();
-        callback_ring_->function = method;
-      }
+    if (method)
+      add_cb(method);
   }
   /// ProtoSignal destructor releases all resources associated with this signal.
   ~ProtoSignal ()
   {
-    if (callback_ring_)
-      {
-        while (callback_ring_->next != callback_ring_)
-          callback_ring_->next->unlink();
-        assert (callback_ring_->ref_count >= 2);
-        callback_ring_->decref();
-        callback_ring_->decref();
-      }
   }
+
   /// Operator to add a new function or lambda as signal handler, returns a handler connection ID.
-  size_t connect (const CbFunction &cb)      { ensure_ring(); return callback_ring_->add_before (cb); }
+  size_t connect (const CbFunction &cb)      { return add_cb(cb); }
   /// Operator to remove a signal handler through it connection ID, returns if a handler was removed.
-  bool   disconnect (size_t connection)         { return callback_ring_ ? callback_ring_->remove_sibling (connection) : false; }
+  bool   disconnect (size_t connection)         { return remove_cb(connection); }
+
   /// Emit a signal, i.e. invoke all its callbacks and collect return types with the Collector.
   CollectorResult
   emit (Args... args)
   {
     Collector collector;
-    if (!callback_ring_)
-      return collector.result();
-    SignalLink *link = callback_ring_;
-    link->incref();
-    do
-      {
-        if (link->function != nullptr)
-          {
-            const bool continue_emission = this->invoke (collector, link->function, args...);
+    for (auto &slot : callback_list_) {
+        if (slot) {
+            const bool continue_emission = this->invoke (collector, *slot, args...);
             if (!continue_emission)
               break;
-          }
-        SignalLink *old = link;
-        link = old->next;
-        link->incref();
-        old->decref();
-      }
-    while (link != callback_ring_);
-    link->decref();
+        }
+    }
     return collector.result();
   }
   // Number of connected slots.
-  int
+  std::size_t
   size ()
   {
-    int size = 0;
-    SignalLink *link = callback_ring_;
-    link->incref();
-    do
-      {
-        if (link->function != 0)
-          {
-            size++;
-          }
-        SignalLink *old = link;
-        link = old->next;
-        link->incref();
-        old->decref();
-      }
-    while (link != callback_ring_);
-    link->decref();
-    return size;
+    return callback_list_.size();
   }
 };
 


### PR DESCRIPTION
I don't understand why a handmade linked list/ring was used here, with manual reference count. Don't we have std::list and std::shared_ptr for this kind of job? Can some one explain to me the rationale behind that?

I change the linked list to std::list, and the reference counting logic to std::shared_ptr, it passed the test cases. Because of the std::list overhead, now per emission size is 24 bytes compare to 8 bytes, I suppose when more slots are connected, the difference will be smaller. On my Mac, the peak memory used by the master implementation and  my version are almost the same, 892928 vs 901120.

But surprisingly, the latency of my version is much smaller, on my 2013 Mac pro, with 3.5 GHz 6-Core Intel Xeon E5, the master implementation took 22.417022ns per emission. My version only took 4.695005ns.

```
> time -l ./test.master
Signal/Basic Tests: OK
Signal/CollectorVector: OK
Signal/CollectorUntil0: OK
Signal/CollectorWhile0: OK
Signal/Benchmark: Simple::Signal: OK
  Benchmark: Simple::Signal: 22.417022ns per emission (size=8): OK
Signal/Benchmark: callback loop: OK
  Benchmark: callback loop: 0.014000ns per round: OK
        0.02 real         0.02 user         0.00 sys
    892928  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
       221  page reclaims
         9  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         1  voluntary context switches
         8  involuntary context switches
```

```
> time -l ./test.list
Signal/Basic Tests: OK
Signal/CollectorVector: OK
Signal/CollectorUntil0: OK
Signal/CollectorWhile0: OK
Signal/Benchmark: Simple::Signal: OK
  Benchmark: Simple::Signal: 4.695005ns per emission (size=24): OK
Signal/Benchmark: callback loop: OK
  Benchmark: callback loop: 0.001000ns per round: OK
        0.01 real         0.00 user         0.00 sys
    901120  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
       221  page reclaims
        11  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         1  voluntary context switches
         5  involuntary context switches
```